### PR TITLE
Hotfix: Typo in GitHub Actions workflow YAML file

### DIFF
--- a/.github/workflows/realease-on-pr-merge.yaml
+++ b/.github/workflows/realease-on-pr-merge.yaml
@@ -56,7 +56,7 @@ jobs:
           echo "new_tag=$NEW_TAG" >> $GITHUB_OUTPUT
           
           git push origin HEAD
-          git put origin "refs/tags/$NEW_TAG"
+          git push origin "refs/tags/$NEW_TAG"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
Corrected 'git put' to 'git push' to ensure tags are properly pushed to the repository during the release process. This change ensures that the release workflow functions as intended.

@coderabbitai summary

Close #64