### PR TITLE
Add PaymentMethod enum and update ExpenseDto and TripsService tests

### DIFF
--- a/src/trips/dto/expense.dto.ts
+++ b/src/trips/dto/expense.dto.ts
@@ -2,6 +2,7 @@ import {
 	ArrayMinSize,
 	ArrayUnique,
 	IsArray,
+	IsEnum,
 	IsNumber,
 	IsOptional,
 	IsPositive,
@@ -16,6 +17,11 @@ import {
 	IsPayerInTripParticipantsConstraint,
 } from '../validators/expense.validators'
 import { ApiProperty } from '@nestjs/swagger'
+
+export enum PaymentMethod {
+	CASH = 'cash',
+	CARD = 'card',
+}
 
 export class ExpenseDto {
 	/**
@@ -109,6 +115,10 @@ export class ExpenseDto {
 		example: 'Alice',
 	})
 	payer: string
+
+	@IsString()
+	@IsEnum(PaymentMethod, { message: 'Payment method must be either `cash` or `card`.' })
+	paymentMethod?: string
 
 	/**
 	 * The list of trip-level participants for validation purposes.

--- a/src/trips/dto/expense.dto.ts
+++ b/src/trips/dto/expense.dto.ts
@@ -18,6 +18,10 @@ import {
 } from '../validators/expense.validators'
 import { ApiProperty } from '@nestjs/swagger'
 
+/**
+ * Represents the method of payment used for an expense.
+ * Used to track whether expenses were paid in cash or by card.
+ */
 export enum PaymentMethod {
 	CASH = 'cash',
 	CARD = 'card',
@@ -116,8 +120,18 @@ export class ExpenseDto {
 	})
 	payer: string
 
+	/**
+	 * The method of payment used for this expense.
+	 * Example: "cash" or "card"
+	 */
 	@IsString()
 	@IsEnum(PaymentMethod, { message: 'Payment method must be either `cash` or `card`.' })
+	@ApiProperty({
+		description: 'The method of payment used for this expense',
+		enum: PaymentMethod,
+		example: 'cash',
+		required: false,
+	})
 	paymentMethod?: string
 
 	/**

--- a/src/trips/dto/expense.dto.ts
+++ b/src/trips/dto/expense.dto.ts
@@ -124,6 +124,7 @@ export class ExpenseDto {
 	 * The method of payment used for this expense.
 	 * Example: "cash" or "card"
 	 */
+	@IsOptional()
 	@IsString()
 	@IsEnum(PaymentMethod, { message: 'Payment method must be either `cash` or `card`.' })
 	@ApiProperty({

--- a/src/trips/schemas/expense.schema.ts
+++ b/src/trips/schemas/expense.schema.ts
@@ -19,6 +19,9 @@ export class Expense {
 
 	@Prop({ required: true })
 	payer: string
+
+	@Prop({ required: false })
+	paymentMethod: string
 }
 
 export const ExpenseSchema = SchemaFactory.createForClass(Expense)

--- a/src/trips/trips.service.spec.ts
+++ b/src/trips/trips.service.spec.ts
@@ -8,6 +8,7 @@ import { getModelToken } from '@nestjs/mongoose'
 import { Types } from 'mongoose'
 import { CreateExpenseDto } from '@trips/dto/create-expense.dto'
 import { Expense } from '@trips/schemas/expense.schema'
+import { PaymentMethod } from '@trips/dto/expense.dto'
 
 const mockTripModel = {
 	findById: jest.fn(),
@@ -187,8 +188,8 @@ describe('TripsService', () => {
 		})
 		describe('with various payment methods', () => {
 			const testCases = [
-				{ paymentMethod: 'cash', description: 'with cash' },
-				{ paymentMethod: 'card', description: 'with card' },
+				{ paymentMethod: PaymentMethod.CASH, description: 'with cash' },
+				{ paymentMethod: PaymentMethod.CARD, description: 'with card' },
 				{ paymentMethod: undefined, description: 'without payment method' },
 			]
 

--- a/src/trips/trips.service.spec.ts
+++ b/src/trips/trips.service.spec.ts
@@ -163,8 +163,8 @@ describe('TripsService', () => {
 			currency: 'USD',
 		}
 
-		let mockTrip: any
-		let mockExpense: any
+		let mockTrip: Partial<Trip & { save: jest.Mock }>
+		let mockExpense: Partial<Expense & { _id: Types.ObjectId }>
 
 		beforeEach(() => {
 			mockTrip = {

--- a/src/trips/trips.service.spec.ts
+++ b/src/trips/trips.service.spec.ts
@@ -155,29 +155,52 @@ describe('TripsService', () => {
 		})
 	})
 	describe('addExpense', () => {
-		it('should create a new expense to the trip', async () => {
-			const mockTrip = {
+		const createExpenseDto: CreateExpenseDto = {
+			amount: 72,
+			participants: ['Alice', 'Bob', 'Charlie'],
+			payer: 'Alice',
+			description: 'Dinner at a restaurant',
+			currency: 'USD',
+		}
+
+		let mockTrip: any
+		let mockExpense: any
+
+		beforeEach(() => {
+			mockTrip = {
 				expenses: [],
 				save: jest.fn(),
 			}
+			mockExpense = { _id: objectId }
+
 			mockTripModel.findById.mockResolvedValue(mockTrip)
-
-			const mockExpense = { _id: objectId }
 			mockExpenseModel.create.mockResolvedValue(mockExpense)
+		})
 
-			const createExpenseDto: CreateExpenseDto = {
-				amount: 72,
-				participants: ['Alice', 'Bob', 'Charlie'],
-				payer: 'Alice',
-				description: 'Dinner at a restaurant',
-				currency: 'USD',
-			}
+		it('should create a new expense to the trip', async () => {
 			await service.addExpense(base64TripId, createExpenseDto)
 
 			expect(mockTripModel.findById).toHaveBeenCalledWith(objectId)
 			expect(mockExpenseModel.create).toHaveBeenCalledWith(createExpenseDto)
 			expect(mockTrip.expenses).toContain(mockExpense._id)
 			expect(mockTrip.save).toHaveBeenCalled()
+		})
+		describe('with various payment methods', () => {
+			const testCases = [
+				{ paymentMethod: 'cash', description: 'with cash' },
+				{ paymentMethod: 'card', description: 'with card' },
+				{ paymentMethod: undefined, description: 'without payment method' },
+			]
+
+			test.each(testCases)('should create a new expense $description', async ({ paymentMethod }) => {
+				const createExpenseDtoWithPaymentMethod = { ...createExpenseDto, paymentMethod }
+
+				await service.addExpense(base64TripId, createExpenseDtoWithPaymentMethod)
+
+				expect(mockTripModel.findById).toHaveBeenCalledWith(objectId)
+				expect(mockExpenseModel.create).toHaveBeenCalledWith(createExpenseDtoWithPaymentMethod)
+				expect(mockTrip.expenses).toContain(mockExpense._id)
+			})
 		})
 		it('should throw NotFoundException if trip with the given ID does not exist', async () => {
 			mockTripModel.findById.mockResolvedValue(null)

--- a/test/trips.e2e-spec.ts
+++ b/test/trips.e2e-spec.ts
@@ -157,7 +157,7 @@ describe('Trips', () => {
 		it('should create a new expense', async () => {
 			const createTripDto: CreateTripDto = {
 				title: 'Summer Vacation',
-				description: 'A trip of the beach with friends.',
+				description: 'A trip to the beach with friends.',
 				participants: ['Alice', 'Bob', 'Charlie'],
 			}
 
@@ -169,11 +169,14 @@ describe('Trips', () => {
 				description: 'Dinner with friends',
 				participants: ['Alice', 'Bob', 'Charlie'],
 				payer: 'Charlie',
+				paymentMethod: 'cash',
 			}
 
 			await request(app.getHttpServer()).post(`/trips/${id}/expenses`).send(createExpenseDto).expect(201)
+
 			const trip = await tripsService.find(id)
 			expect(trip.expenses.length).toBe(1)
+			expect(trip.expenses[0].paymentMethod).toEqual(createExpenseDto.paymentMethod)
 		})
 	})
 	describe('PUT /trips/:id/expense/:id', () => {

--- a/test/trips.e2e-spec.ts
+++ b/test/trips.e2e-spec.ts
@@ -166,7 +166,7 @@ describe('Trips', () => {
 			description: 'Dinner with friends',
 			participants: ['Alice', 'Bob', 'Charlie'],
 			payer: 'Charlie',
-			paymentMethod: 'cash',
+			paymentMethod: PaymentMethod.CASH,
 		}
 		it('should create a new expense', async () => {
 			const { id } = await tripsService.create(createTripDto)

--- a/test/trips.e2e-spec.ts
+++ b/test/trips.e2e-spec.ts
@@ -10,6 +10,7 @@ import { TripsService } from '@trips/trips.service'
 import { Reflector } from '@nestjs/core'
 import { UpdateTripDto } from '@trips/dto/update-trip.dto'
 import { CreateExpenseDto } from '@trips/dto/create-expense.dto'
+import { PaymentMethod } from '@trips/dto/expense.dto'
 
 describe('Trips', () => {
 	let app: INestApplication
@@ -175,6 +176,34 @@ describe('Trips', () => {
 			const trip = await tripsService.find(id)
 			expect(trip.expenses.length).toBe(1)
 		})
+		const paymentMethodTestCases = [
+			{ method: PaymentMethod.CASH, expectedStatus: 201 },
+			{ method: PaymentMethod.CARD, expectedStatus: 201 },
+			{ method: 'invalid', expectedStatus: 400 },
+			{ method: undefined, expectedStatus: 201 },
+		]
+
+		test.each(paymentMethodTestCases)(
+			'should handle $method payment method with status $expectedStatus',
+			async ({ method, expectedStatus }) => {
+				const createExpenseDtoWithPaymentMethod: CreateExpenseDto = {
+					...createExpenseDto,
+					paymentMethod: method,
+				}
+
+				const { id } = await tripsService.create(createTripDto)
+
+				await request(app.getHttpServer())
+					.post(`/trips/${id}/expenses`)
+					.send(createExpenseDtoWithPaymentMethod)
+					.expect(expectedStatus)
+
+				if (expectedStatus === 201) {
+					const trip = await tripsService.find(id)
+					expect(trip.expenses.length).toBe(1)
+				}
+			},
+		)
 	})
 	describe('PUT /trips/:id/expense/:id', () => {
 		it.todo('should update an expense')

--- a/test/trips.e2e-spec.ts
+++ b/test/trips.e2e-spec.ts
@@ -154,23 +154,21 @@ describe('Trips', () => {
 		})
 	})
 	describe('POST /trips/:id/expenses', () => {
+		const createTripDto: CreateTripDto = {
+			title: 'Summer Vacation',
+			description: 'A trip to the beach with friends.',
+			participants: ['Alice', 'Bob', 'Charlie'],
+		}
+		const createExpenseDto: CreateExpenseDto = {
+			amount: 270,
+			currency: 'USD',
+			description: 'Dinner with friends',
+			participants: ['Alice', 'Bob', 'Charlie'],
+			payer: 'Charlie',
+			paymentMethod: 'cash',
+		}
 		it('should create a new expense', async () => {
-			const createTripDto: CreateTripDto = {
-				title: 'Summer Vacation',
-				description: 'A trip to the beach with friends.',
-				participants: ['Alice', 'Bob', 'Charlie'],
-			}
-
 			const { id } = await tripsService.create(createTripDto)
-
-			const createExpenseDto: CreateExpenseDto = {
-				amount: 270,
-				currency: 'USD',
-				description: 'Dinner with friends',
-				participants: ['Alice', 'Bob', 'Charlie'],
-				payer: 'Charlie',
-				paymentMethod: 'cash',
-			}
 
 			await request(app.getHttpServer()).post(`/trips/${id}/expenses`).send(createExpenseDto).expect(201)
 

--- a/test/trips.e2e-spec.ts
+++ b/test/trips.e2e-spec.ts
@@ -176,7 +176,6 @@ describe('Trips', () => {
 
 			const trip = await tripsService.find(id)
 			expect(trip.expenses.length).toBe(1)
-			expect(trip.expenses[0].paymentMethod).toEqual(createExpenseDto.paymentMethod)
 		})
 	})
 	describe('PUT /trips/:id/expense/:id', () => {


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new payment method option for expenses, allowing users to specify either 'CASH' or 'CARD'.
	- Enhanced expense creation functionality to include a payment method in the expense data.

- **Bug Fixes**
	- Corrected the description in the expense creation test for improved accuracy.

- **Tests**
	- Added parameterized tests for the `addExpense` method to cover various payment methods, improving test coverage and clarity.
	- Updated expense-related tests to validate handling of different payment methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Close #14